### PR TITLE
Correctly support guest users in teams

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "contentUrl": "https://<<BASE_URI_DOMAIN>>/tab/silent?upn={upn}",
+      "contentUrl": "https://<<BASE_URI_DOMAIN>>/tab/silent?upn={upn}&tenantId={tid}",
       "entityId": "silentAuth",
       "name": "Silent Auth",
       "scopes": [

--- a/src/providers/AzureADv1Provider.ts
+++ b/src/providers/AzureADv1Provider.ts
@@ -30,7 +30,7 @@ import { UserToken, IOAuth2Provider } from "./OAuth2Provider";
 // AzureAD v1 API
 // =========================================================
 
-const authorizationUrl = "https://login.microsoftonline.com/common/oauth2/authorize";
+const authorizationUrl = "https://login.microsoftonline.com/{tenant}/oauth2/authorize";
 const accessTokenUrl = "https://login.microsoftonline.com/common/oauth2/token";
 const callbackPath = "/auth/azureADv1/callback";
 const graphProfileUrl = "https://graph.microsoft.com/v1.0/me";
@@ -51,7 +51,10 @@ export class AzureADv1Provider implements IOAuth2Provider {
     }
 
     // Return the url the user should navigate to to authenticate the app
-    public getAuthorizationUrl(state: string, extraParams?: any): string {
+    public getAuthorizationUrl(state: string, extraParams?: any, tenant?: string): string {
+        // Determine the tenant endpoint to use, defaulting to "common"
+        tenant = tenant || "common";
+
         let params = {
             response_type: "code",
             response_mode: "query",
@@ -63,7 +66,9 @@ export class AzureADv1Provider implements IOAuth2Provider {
         if (extraParams) {
             params = { ...extraParams, ...params };
         }
-        return authorizationUrl + "?" + querystring.stringify(params);
+
+        let authorizationUrlWithTenant = authorizationUrl.replace("{tenant}", tenant);
+        return authorizationUrlWithTenant + "?" + querystring.stringify(params);
     }
 
     // Redeem the authorization code for an access token

--- a/src/views/tab/silent/silent-start.hbs
+++ b/src/views/tab/silent/silent-start.hbs
@@ -38,6 +38,9 @@
             microsoftTeams.getContext(function (context) {
                 // ADAL.js configuration
                 let config = {
+                    // Use the tenant id of the current organization. For guest users, we want an access token for 
+                    // the tenant we are currently in, not the home tenant of the guest. 
+                    tenant: context.tid,
                     clientId: "{{appId}}",
                     redirectUri: window.location.origin + "/tab/silent-end",       // This should be in the list of redirect uris for the AAD app
                     cacheLocation: "localStorage",

--- a/src/views/tab/silent/silent.hbs
+++ b/src/views/tab/silent/silent.hbs
@@ -44,8 +44,9 @@
             <div id="divError" style="display: none"></div>
             <div id="divProfile" style="display: none">
                 <div><b>Name:</b> <span id="profileDisplayName"/></div>
-                <div><b>UPN:</b> <span id="profileUpn"/></div>
                 <div><b>Object id:</b> <span id="profileObjectId"/></div>
+                <div><b>UPN:</b> <span id="profileUpn"/></div>
+                <div><b>Unique name:</b> <span id="profileUniqueName"/></div>
             </div>
         </p>
 
@@ -62,8 +63,13 @@
             let queryParams = getQueryParameters();
             let upn = queryParams["upn"];
 
+            // Use the tenant id of the current organization. For guest users, we want an access token for 
+            // the tenant we are currently in, not the home tenant of the guest. 
+            let tenantId = queryParams["tenantId"] || "common";
+
             // ADAL.js configuration
             let config = {
+                tenant: tenantId,
                 clientId: "{{appId}}",
                 redirectUri: window.location.origin + "/tab/silent-end",     // This should be in the list of redirect uris for the AAD app
                 cacheLocation: "localStorage",
@@ -165,8 +171,13 @@
                     },
                     success: function (token) {
                         $("#profileDisplayName").text(token.name);
-                        $("#profileUpn").text(token.upn);
                         $("#profileObjectId").text(token.oid);
+                        $("#profileUpn").text(token.upn);
+
+                        // The id token for a guest (external) user will not have a "upn" claim.
+                        // Instead it has a "unique_name" claim, which is the username in the home organization/identity provider.
+                        $("#profileUniqueName").text(token.unique_name);
+
                         $("#divProfile").css({ display: "" });
                         $("#divError").css({ display: "none" });
                     },

--- a/src/views/tab/simple/simple-start-v2.hbs
+++ b/src/views/tab/simple/simple-start-v2.hbs
@@ -42,16 +42,25 @@
                     scope: "https://graph.microsoft.com/User.Read openid",
                     redirect_uri: window.location.origin + "/tab/simple-end",
                     nonce: _guid(),
-                    state: state,
-                    // login_hint pre-fills the username/email address field of the sign in page for the user, 
-                    // if you know their username ahead of time.
-                    login_hint: context.upn,
+                    state: state
                 };
 
-                // Go to the AzureAD authorization endpoint
-                let authorizeEndpoint = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?" + toQueryString(queryParams);
+                // login_hint pre-fills the username/email address field of the sign in page for the user, 
+                // if you know their username ahead of time.
+                if (!isExternalUpn(context.upn)) {
+                    queryParams.login_hint = context.upn;
+                }
+
+                // Go to the AzureAD authorization endpoint (tenant-specific endpoint, not "common")
+                // For guest users, we want an access token for the tenant we are currently in, not the home tenant of the guest. 
+                let authorizeEndpoint = `https://login.microsoftonline.com/${context.tid}/oauth2/v2.0/authorize?` + toQueryString(queryParams);
                 window.location.assign(authorizeEndpoint);
             });
+
+            // Determine if UPN is externally authenticated (e.g., guest user)
+            function isExternalUpn(upn) {
+                return (upn.indexOf("#EXT#@") >= 0); 
+            }
 
             // Build query string from map of query parameter
             function toQueryString(queryParams) {

--- a/src/views/tab/simple/simple-start.hbs
+++ b/src/views/tab/simple/simple-start.hbs
@@ -42,16 +42,25 @@
                     resource: "https://graph.microsoft.com/",
                     redirect_uri: window.location.origin + "/tab/simple-end",
                     nonce: _guid(),
-                    state: state,
-                    // login_hint pre-fills the username/email address field of the sign in page for the user, 
-                    // if you know their username ahead of time.
-                    login_hint: context.upn,
+                    state: state
                 };
 
-                // Go to the AzureAD authorization endpoint
-                let authorizeEndpoint = "https://login.microsoftonline.com/common/oauth2/authorize?" + toQueryString(queryParams);
+                // login_hint pre-fills the username/email address field of the sign in page for the user, 
+                // if you know their username ahead of time.
+                if (!isExternalUpn(context.upn)) {
+                    queryParams.login_hint = context.upn;
+                }
+
+                // Go to the AzureAD authorization endpoint (tenant-specific endpoint, not "common")
+                // For guest users, we want an access token for the tenant we are currently in, not the home tenant of the guest. 
+                let authorizeEndpoint = `https://login.microsoftonline.com/${context.tid}/oauth2/authorize?` + toQueryString(queryParams);
                 window.location.assign(authorizeEndpoint);
             });
+
+            // Determine if UPN is externally authenticated (e.g., guest user)
+            function isExternalUpn(upn) {
+                return (upn.indexOf("#EXT#@") >= 0); 
+            }
 
             // Build query string from map of query parameter
             function toQueryString(queryParams) {


### PR DESCRIPTION
- Get AAD tokens from the tenant-specific endpoint
- Do not use the externally-authenticated UPN as a login hint

Prior to these changes, we were getting tokens for the guest user's home tenant, not the tenant that the app is currently in.