### PR TITLE
Update sample to use new identity hints

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "contentUrl": "https://<<BASE_URI_DOMAIN>>/tab/silent?upn={upn}&tenantId={tid}",
+      "contentUrl": "https://<<BASE_URI_DOMAIN>>/tab/silent?loginHint={loginHint}&userObjectId={userObjectId}&tenantId={tid}",
       "entityId": "silentAuth",
       "name": "Silent Auth",
       "scopes": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "base64url": "^2.0.0",
     "body-parser": "^1.16.1",
     "botbuilder": "^3.11.0",
-    "botbuilder-teams": "0.1.7",
+    "botbuilder-teams": "0.2.1",
     "config": "^1.25.1",
     "debug": "~2.2.0",
     "express": "~4.13.1",

--- a/src/views/tab/silent/silent-start.hbs
+++ b/src/views/tab/silent/silent-start.hbs
@@ -50,17 +50,17 @@
                 // Setup extra query parameters for ADAL
                 // - openid and profile scope adds profile information to the id_token
                 // - login_hint provides the expected user name
-                if (context.upn) {
-                    config.extraQueryParameters = "scope=openid+profile&login_hint=" + encodeURIComponent(context.upn);
+                if (context.loginHint) {
+                    config.extraQueryParameter = "scope=openid+profile&login_hint=" + encodeURIComponent(context.loginHint);
                 } else {
-                    config.extraQueryParameters = "scope=openid+profile";              
+                    config.extraQueryParameter = "scope=openid+profile";              
                 }
     
                 // Use a custom displayCall function to add extra query parameters to the url before navigating to it
                 config.displayCall = function (urlNavigate) {
                     if (urlNavigate) {
-                        if (config.extraQueryParameters) {
-                            urlNavigate += "&" + config.extraQueryParameters;
+                        if (config.extraQueryParameter) {
+                            urlNavigate += "&" + config.extraQueryParameter;
                         }
                         window.location.replace(urlNavigate);
                     }

--- a/src/views/tab/silent/silent.hbs
+++ b/src/views/tab/silent/silent.hbs
@@ -61,7 +61,8 @@
     
             // Parse query parameters
             let queryParams = getQueryParameters();
-            let upn = queryParams["upn"];
+            let loginHint = queryParams["loginHint"];
+            let userObjectId = queryParams["userObjectId"];
 
             // Use the tenant id of the current organization. For guest users, we want an access token for 
             // the tenant we are currently in, not the home tenant of the guest. 
@@ -79,10 +80,10 @@
             // Setup extra query parameters for ADAL
             // - openid and profile scope adds profile information to the id_token
             // - login_hint provides the expected user name
-            if (upn) {
-                config.extraQueryParameters = "scope=openid+profile&login_hint=" + encodeURIComponent(upn);
+            if (loginHint) {
+                config.extraQueryParameter = "scope=openid+profile&login_hint=" + encodeURIComponent(loginHint);
             } else {
-                config.extraQueryParameters = "scope=openid+profile";              
+                config.extraQueryParameter = "scope=openid+profile";              
             }
     
             let authContext = new AuthenticationContext(config);
@@ -90,7 +91,7 @@
             // See if there's a cached user and it matches the expected user
             let user = authContext.getCachedUser();
             if (user) {
-                if (user.userName !== upn) {
+                if (user.profile.oid !== userObjectId) {
                     // User doesn't match, clear the cache
                     authContext.clearCache();
                 }

--- a/src/views/tab/simple/simple-start-v2.hbs
+++ b/src/views/tab/simple/simple-start-v2.hbs
@@ -42,25 +42,15 @@
                     scope: "https://graph.microsoft.com/User.Read openid",
                     redirect_uri: window.location.origin + "/tab/simple-end",
                     nonce: _guid(),
-                    state: state
+                    state: state,
+                    login_hint: context.loginHint,
                 };
-
-                // login_hint pre-fills the username/email address field of the sign in page for the user, 
-                // if you know their username ahead of time.
-                if (!isExternalUpn(context.upn)) {
-                    queryParams.login_hint = context.upn;
-                }
 
                 // Go to the AzureAD authorization endpoint (tenant-specific endpoint, not "common")
                 // For guest users, we want an access token for the tenant we are currently in, not the home tenant of the guest. 
                 let authorizeEndpoint = `https://login.microsoftonline.com/${context.tid}/oauth2/v2.0/authorize?` + toQueryString(queryParams);
                 window.location.assign(authorizeEndpoint);
             });
-
-            // Determine if UPN is externally authenticated (e.g., guest user)
-            function isExternalUpn(upn) {
-                return (upn.indexOf("#EXT#@") >= 0); 
-            }
 
             // Build query string from map of query parameter
             function toQueryString(queryParams) {

--- a/src/views/tab/simple/simple-start.hbs
+++ b/src/views/tab/simple/simple-start.hbs
@@ -42,25 +42,15 @@
                     resource: "https://graph.microsoft.com/",
                     redirect_uri: window.location.origin + "/tab/simple-end",
                     nonce: _guid(),
-                    state: state
+                    state: state,
+                    login_hint: context.loginHint,
                 };
-
-                // login_hint pre-fills the username/email address field of the sign in page for the user, 
-                // if you know their username ahead of time.
-                if (!isExternalUpn(context.upn)) {
-                    queryParams.login_hint = context.upn;
-                }
 
                 // Go to the AzureAD authorization endpoint (tenant-specific endpoint, not "common")
                 // For guest users, we want an access token for the tenant we are currently in, not the home tenant of the guest. 
                 let authorizeEndpoint = `https://login.microsoftonline.com/${context.tid}/oauth2/authorize?` + toQueryString(queryParams);
                 window.location.assign(authorizeEndpoint);
             });
-
-            // Determine if UPN is externally authenticated (e.g., guest user)
-            function isExternalUpn(upn) {
-                return (upn.indexOf("#EXT#@") >= 0); 
-            }
 
             // Build query string from map of query parameter
             function toQueryString(queryParams) {


### PR DESCRIPTION
- loginHint instead of upn (works for all kinds of users)
- compare userObjectId instead of upn to check that the cached token is for the correct user