### PR TITLE
Remove the custom displayCall function

### DIFF
--- a/src/views/tab/silent/silent-start.hbs
+++ b/src/views/tab/silent/silent-start.hbs
@@ -56,16 +56,6 @@
                     config.extraQueryParameter = "scope=openid+profile";              
                 }
     
-                // Use a custom displayCall function to add extra query parameters to the url before navigating to it
-                config.displayCall = function (urlNavigate) {
-                    if (urlNavigate) {
-                        if (config.extraQueryParameter) {
-                            urlNavigate += "&" + config.extraQueryParameter;
-                        }
-                        window.location.replace(urlNavigate);
-                    }
-                }
-
                 // Navigate to the AzureAD login page        
                 let authContext = new AuthenticationContext(config);
                 authContext.login();


### PR DESCRIPTION
Since we fixed the name of the "extraQueryParameter" property, the scope and login_hint are already added, so we don't need a custom displayCall function.