### PR TITLE
Update the callback page to check window.parent

### DIFF
--- a/src/views/tab/silent/silent-end.hbs
+++ b/src/views/tab/silent/silent-end.hbs
@@ -45,8 +45,8 @@
 
             if (authContext.isCallback(window.location.hash)) {
                 authContext.handleWindowCallback(window.location.hash);
-                // Only call notifySuccess or notifyFailure if this page is in the authentication popup
-                if (window.opener) {
+                // Only call notifySuccess or notifyFailure if this page is in the authentication popup (not iframed)
+                if (window.parent === window) {
                     if (authContext.getCachedUser()) {
                         microsoftTeams.authentication.notifySuccess();
                     } else {


### PR DESCRIPTION
On mobile clients window.opener is null, unlike desktop. Since we are effectively checking to see if we are running inside a top-level window, we can determine this with `window.parent === window`.